### PR TITLE
・プロジェクト内のフィールド全てエンターキーでsubmitできるように変更

### DIFF
--- a/angular-app/angular.json
+++ b/angular-app/angular.json
@@ -99,8 +99,9 @@
               "src/assets"
             ],
             "styles": [
-              "src/styles.scss"
-            ],
+              "src/styles.scss",
+              "node_modules/ngx-toastr/toastr.css"
+              ],
             "scripts": []
           }
         }

--- a/angular-app/package-lock.json
+++ b/angular-app/package-lock.json
@@ -21,6 +21,7 @@
         "@angular/router": "^15.2.0",
         "firebase": "^9.14.0",
         "firebase-tools": "^11.0.0",
+        "ngx-toastr": "^16.2.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.12.0"
@@ -23568,6 +23569,19 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+    },
+    "node_modules/ngx-toastr": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/ngx-toastr/-/ngx-toastr-16.2.0.tgz",
+      "integrity": "sha512-7X6UhOKiaUeC2eTOsUqctZH0ZWKG8VlzDxWJhdEF1N3kPod46SU/Vn2l0hbt8EDwTjxHKfKyevU2idkYDoZYog==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=14.0.0-0",
+        "@angular/core": ">=14.0.0-0",
+        "@angular/platform-browser": ">=14.0.0-0"
+      }
     },
     "node_modules/nice-napi": {
       "version": "1.0.2",

--- a/angular-app/package.json
+++ b/angular-app/package.json
@@ -23,6 +23,7 @@
     "@angular/router": "^15.2.0",
     "firebase": "^9.14.0",
     "firebase-tools": "^11.0.0",
+    "ngx-toastr": "^16.2.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.12.0"

--- a/angular-app/src/app/app.module.ts
+++ b/angular-app/src/app/app.module.ts
@@ -12,6 +12,7 @@ import { MatIconModule } from '@angular/material/icon'; // 追加
 import {MatChipsModule} from '@angular/material/chips';
 import {MatProgressBarModule} from '@angular/material/progress-bar';
 import {MatDialogModule} from '@angular/material/dialog';
+import { ToastrModule } from 'ngx-toastr';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -54,6 +55,8 @@ import { LobbyComponent } from './pages/lobby/lobby.component';
     LobbyComponent
   ],
   imports: [
+    BrowserAnimationsModule,
+    ToastrModule.forRoot(),
     MatProgressBarModule,
     MatDialogModule,
     MatChipsModule,

--- a/angular-app/src/app/components/create-room-dialog/create-room-dialog.component.html
+++ b/angular-app/src/app/components/create-room-dialog/create-room-dialog.component.html
@@ -11,7 +11,6 @@
       color="accent"
       cdkFocusInitial
       (click)="roomCreation()"
-      [mat-dialog-close]
     >
       作成
     </button>

--- a/angular-app/src/app/components/create-room-dialog/create-room-dialog.component.ts
+++ b/angular-app/src/app/components/create-room-dialog/create-room-dialog.component.ts
@@ -1,4 +1,5 @@
 import { Component, Injectable } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import { FirestoreClientService } from 'src/app/service/firestore-client.service';
 
@@ -12,14 +13,13 @@ import { FirestoreClientService } from 'src/app/service/firestore-client.service
   styleUrls: ['./create-room-dialog.component.scss']
 })
 export class CreateRoomDialogComponent {
-
-  private _roomKey: string = '';
-
   constructor(
-    private firestoreClient: FirestoreClientService
+    private firestoreClient: FirestoreClientService,
+    public dialogRef: MatDialogRef<CreateRoomDialogComponent>,
   ){}
 
   roomCreation(){
+    this.dialogRef.close();
     this.firestoreClient.insertRoom();
   }
 }

--- a/angular-app/src/app/components/entry-dialog/entry-dialog.component.html
+++ b/angular-app/src/app/components/entry-dialog/entry-dialog.component.html
@@ -5,17 +5,12 @@
 
   <div mat-dialog-content align="center">
     <mat-form-field>
-      <input matInput [(ngModel)]="key" />
+      <input matInput [(ngModel)]="key" (keydown.enter)="entryRoom()" />
     </mat-form-field>
   </div>
 
   <div mat-dialog-actions align="center" class="dialog-actions-container">
-    <button
-      mat-raised-button
-      color="primary"
-      (click)="this.entryRoom()"
-      [mat-dialog-close]
-    >
+    <button mat-raised-button color="primary" (click)="entryRoom()">
       参加
     </button>
   </div>

--- a/angular-app/src/app/components/entry-dialog/entry-dialog.component.ts
+++ b/angular-app/src/app/components/entry-dialog/entry-dialog.component.ts
@@ -23,8 +23,8 @@ export class EntryDialogComponent {
   }
 
   entryRoom(){
+    this.dialogRef.close();
     this.firestoreClient.putUser(this.key, false);
     this.router.navigateByUrl('/lobby');
-
   }
 }

--- a/angular-app/src/app/pages/answer-game-screen/answer-game-screen.component.html
+++ b/angular-app/src/app/pages/answer-game-screen/answer-game-screen.component.html
@@ -10,7 +10,13 @@
       class="answer-field-width answer-field-margin"
     >
       <mat-label>回答を入力</mat-label>
-      <input matInput type="number" maxlength="8" [(ngModel)]="answer" />
+      <input
+        matInput
+        type="number"
+        maxlength="8"
+        [(ngModel)]="answer"
+        (keydown.enter)="checkAnswer()"
+      />
     </mat-form-field>
 
     <button mat-raised-button color="accent" (click)="checkAnswer()">

--- a/angular-app/src/app/pages/answer-game-screen/answer-game-screen.component.html
+++ b/angular-app/src/app/pages/answer-game-screen/answer-game-screen.component.html
@@ -22,12 +22,12 @@
     class="time-margin time-size"
     color="accent"
     mode="determinate"
-    [value]="80"
+    [value]="(remainingTime / starttimeLimit) * 100"
   >
   </mat-progress-bar>
 
   <span class="time-text">
     <span>time</span>
-    {{ 80 }}s
+    {{ remainingTime }}s
   </span>
 </div>

--- a/angular-app/src/app/pages/answer-game-screen/answer-game-screen.component.ts
+++ b/angular-app/src/app/pages/answer-game-screen/answer-game-screen.component.ts
@@ -1,4 +1,8 @@
 import { Component } from '@angular/core';
+import { Firestore, doc, onSnapshot } from '@angular/fire/firestore';
+import { Router } from '@angular/router';
+import { Subscription } from 'rxjs';
+import { FirestoreClientService } from 'src/app/service/firestore-client.service';
 import { QuizService } from 'src/app/service/quiz.service';
 
 @Component({
@@ -7,20 +11,49 @@ import { QuizService } from 'src/app/service/quiz.service';
   styleUrls: ['./answer-game-screen.component.scss']
 })
 export class AnswerGameScreenComponent {
+  private TimeLimitSubscription!: Subscription;
+  private unsub = onSnapshot(doc(this.firestore, "rooms", this.firestoreClientService.roomKey), (doc) => {
+    let Hp: number= doc.get('enemyHp');
+    if(Hp <= 0){
+      this.unsub();
+      this.TimeLimitSubscription.unsubscribe();
+      this.quizService.result = '勝ち';
+      this.router.navigateByUrl('/result');
+    }
+  });
 
-  statement = '';
+  statement:string = '';
   quizCount: number = 0;
   answer?: number;
+  remainingTime: number = 0;
+  starttimeLimit: number = this.quizService.startTimeLimit;
 
   constructor(
-    private quizService: QuizService
-  ) {}
+    private firestoreClientService: FirestoreClientService,
+    private quizService: QuizService,
+    private firestore: Firestore,
+    private router: Router
+  ) {
+    this.quizService.timeLimitCount();
+  }
 
   ngOnInit(): void {
+    this.TimeLimitSubscription = this.quizService._timeSub$.subscribe(time =>{
+      if(time == 0){
+        setTimeout(() => {
+          this.TimeLimitSubscription.unsubscribe();
+          this.unsub();
+          this.quizService.result = '負け';
+          this.router.navigateByUrl('/result');
+        }, 1000);
+      }
+      this.remainingTime = time;
+    });
     this.statement = this.quizService.currentQuizStatement;
     this.quizCount = this.quizService.currentQuizCount;
   }
-
+//回答ボタンが押された時の処理
+//正誤判定、問題文と問題数の更新、回答フィールドの値初期化
   checkAnswer(){
     if(this.quizService.checkAnswer(this.answer? this.answer: -1)){
       console.log('正解');
@@ -29,7 +62,6 @@ export class AnswerGameScreenComponent {
     }
     this.statement = this.quizService.currentQuizStatement;
     this.quizCount = this.quizService.currentQuizCount;
-
     this.answer = undefined;
   }
 

--- a/angular-app/src/app/pages/lobby/lobby.component.html
+++ b/angular-app/src/app/pages/lobby/lobby.component.html
@@ -1,7 +1,10 @@
 <div class="top-item-container">
-  <button mat-stroked-button class="back-button">戻る</button>
+  <button mat-stroked-button class="back-button" (click)="backTop()">
+    戻る
+  </button>
   <label
-    ><button mat-stroked-button class="copy-button">コピー</button
+    ><button mat-stroked-button class="copy-button" (click)="copyRoomkey()">
+      コピー</button
     >{{ roomKey }}</label
   >
 </div>

--- a/angular-app/src/app/pages/lobby/lobby.component.html
+++ b/angular-app/src/app/pages/lobby/lobby.component.html
@@ -10,15 +10,18 @@
   <p *ngFor="let user of this.users | async">{{ user.name }}</p>
 </div>
 
+<div class="countdown" [ngStyle]="countFontSize" *ngIf="countdown">
+  {{ countdown }}
+</div>
+
 <div class="button-container">
   <button
     mat-raised-button
-    (click)="startGame()"
+    (click)="hostStartGame()"
     color="accent"
     class="start-button"
     *ngIf="isHost"
   >
     開始
   </button>
-  <button mat-raised-button (click)="test()"></button>
 </div>

--- a/angular-app/src/app/pages/lobby/lobby.component.scss
+++ b/angular-app/src/app/pages/lobby/lobby.component.scss
@@ -29,30 +29,47 @@ label{
 }
 .participants-box::after{
   content:"";
-   display:inline-block;
-   width:3px;
-   height:100%;
-   background-color:#000000;
-   position:absolute;
-   left: calc(33% - 3px);
+  display:inline-block;
+  width:3px;
+  height:100%;
+  background-color:#000000;
+  position:absolute;
+  left: calc(33% - 3px);
 }
 .participants-box::before{
   content:"";
-   display:inline-block;
-   width:3px;
-   height:100%;
-   background-color:#000000;
-   position:absolute;
-   left: calc(66% - 3px);
+  display:inline-block;
+  width:3px;
+  height:100%;
+  background-color:#000000;
+  position:absolute;
+  left: calc(66% - 3px);
 }
 .button-container{
   width: 100%;
-  margin-top: 60px;
   display: flex;
   justify-content: center;
+  position:absolute;
+  top: 90%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  -webkit-transform: translate(-50%, -50%);
+  -ms-transform: translate(-50%, -50%);
 }
 .start-button{
   margin: 30px;
   width: 150px;
   height: 60px;
+}
+.countdown{
+  display: inline-block;
+  position:absolute;
+  font-size: 500px;
+  font-weight: 900;
+  z-index: 1;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  -webkit-transform: translate(-50%, -50%);
+  -ms-transform: translate(-50%, -50%);
 }

--- a/angular-app/src/app/pages/lobby/lobby.component.ts
+++ b/angular-app/src/app/pages/lobby/lobby.component.ts
@@ -1,9 +1,12 @@
 import { Component } from '@angular/core';
 import { Firestore, collection, collectionData, doc, docData, getDocs, onSnapshot, query, where } from '@angular/fire/firestore';
 import { Router } from '@angular/router';
-import { Observable } from 'rxjs';
-import { user } from 'src/app/question';
+import { Observable, Subscription } from 'rxjs';
+import { room, user } from 'src/app/question';
 import { FirestoreClientService } from 'src/app/service/firestore-client.service';
+import { QuizService } from 'src/app/service/quiz.service';
+
+
 
 @Component({
   selector: 'app-lobby',
@@ -11,28 +14,58 @@ import { FirestoreClientService } from 'src/app/service/firestore-client.service
   styleUrls: ['./lobby.component.scss']
 })
 export class LobbyComponent {
+  roomInfo: room= {
+    enemyHp: 0,
+    hostUser: '',
+    startTime: new Date()
+  };
   roomKey: string = '';
   isHost: boolean = false;
-  users: Observable<user[]>
+  users: Observable<user[]>;
+  countdown: string = '';
+  countFontSize = {};
+  private TimerSubscription!: Subscription;
+
   constructor(
     private firestoreClient: FirestoreClientService,
+    private quizService: QuizService,
     private firestore: Firestore,
     private router: Router
   ){
     this.roomKey = this.firestoreClient.roomKey;
-    const userProfileCollection = collection(this.firestore, 'rooms', this.roomKey, 'users');
-    this.users = collectionData(userProfileCollection) as Observable<user[]>;
+    this.users = collectionData(collection(this.firestore, 'rooms', this.roomKey, 'users')) as Observable<user[]>;
+    this.firestoreClient.getRoom(this.roomKey).then(val =>{ this.roomInfo = val; });
   }
   ngOnInit(){
+    this.TimerSubscription = this.quizService._countSub$.subscribe(time =>{
+      if(time.length > 1) {
+        this.countFontSize = {'font-size':'100px'};
+        setTimeout(() => {
+          this.isHost? this.router.navigateByUrl('/game'): this.router.navigateByUrl('/answer');
+          this.TimerSubscription.unsubscribe();
+        }, 1000);
+      }
+      this.countdown = time;
+    });
+
     this.isHost = this.firestoreClient.isHost;
     this.firestoreClient.roomKey = this.roomKey;
+    //ログインしているユーザが参加者の場合のみルームドキュメントのSnapshotインスタンス作成
+    //startTimeフィールドが更新された時のみゲームの開始処理が実行される
+    if(!this.isHost){
+      const unsub = onSnapshot(doc(this.firestore, "rooms", this.firestoreClient.roomKey), (doc) => {
+        let startTime: Date = doc.get('startTime').toDate();
+        if(startTime.getTime() !== this.roomInfo.startTime.getTime()){
+          this.quizService.startTimer(startTime);
+          unsub();
+        }
+      });
+    }
+  }
+  hostStartGame(){
+    this.firestoreClient.updateTime().then(startTime =>{
+      this.quizService.startTimer(startTime);
+    });
   }
 
-  startGame(){
-    this.router.navigateByUrl('/game')//仮
-  }
-  test(){
-    this.router.navigateByUrl('/answer')//仮
-
-  }
 }

--- a/angular-app/src/app/pages/lobby/lobby.component.ts
+++ b/angular-app/src/app/pages/lobby/lobby.component.ts
@@ -5,6 +5,7 @@ import { Observable, Subscription } from 'rxjs';
 import { room, user } from 'src/app/question';
 import { FirestoreClientService } from 'src/app/service/firestore-client.service';
 import { QuizService } from 'src/app/service/quiz.service';
+import { ToastrService } from 'ngx-toastr';
 
 
 
@@ -30,7 +31,8 @@ export class LobbyComponent {
     private firestoreClient: FirestoreClientService,
     private quizService: QuizService,
     private firestore: Firestore,
-    private router: Router
+    private router: Router,
+    private toastr: ToastrService
   ){
     this.roomKey = this.firestoreClient.roomKey;
     this.users = collectionData(collection(this.firestore, 'rooms', this.roomKey, 'users')) as Observable<user[]>;
@@ -67,5 +69,19 @@ export class LobbyComponent {
       this.quizService.startTimer(startTime);
     });
   }
-
+  copyRoomkey(){
+    navigator.clipboard.writeText(this.roomKey).then(
+      () => {
+        this.toastr.success('クリップボードにコピーされました！');
+        /* clipboard successfully set */
+      },
+      () => {
+        console.log('コピーに失敗しました。');
+        /* clipboard write failed */
+      },
+    );
+  }
+  backTop(){
+    this.router.navigateByUrl('/top');
+  }
 }

--- a/angular-app/src/app/pages/main-game-screen/main-game-screen.component.html
+++ b/angular-app/src/app/pages/main-game-screen/main-game-screen.component.html
@@ -7,25 +7,25 @@
     class="hp-margin hp-size"
     color="warn"
     mode="determinate"
-    [value]="value"
+    [value]="(Hp / startHp) * 100"
   >
   </mat-progress-bar>
 
   <span class="hp-text">
     <span style="margin-right: 1em">HP</span>
-    {{ value }}/100
+    {{ Hp }}/{{ startHp }}
   </span>
 
   <mat-progress-bar
     class="time-margin time-size"
     color="accent"
     mode="determinate"
-    [value]="100"
+    [value]="(remainingTime / starttimeLimit) * 100"
   >
   </mat-progress-bar>
 
   <span class="time-text">
     <span>time</span>
-    {{ 100 }}s
+    {{ remainingTime }}s
   </span>
 </div>

--- a/angular-app/src/app/pages/main-game-screen/main-game-screen.component.ts
+++ b/angular-app/src/app/pages/main-game-screen/main-game-screen.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject } from '@angular/core';
 import { Firestore, doc, docData, getDoc, onSnapshot } from '@angular/fire/firestore';
-import { Observable, take } from 'rxjs';
-import { hp } from 'src/app/question';
+import { Router } from '@angular/router';
+import { Observable, Subscription, take } from 'rxjs';
 import { FirestoreClientService } from 'src/app/service/firestore-client.service';
 import { QuizService } from 'src/app/service/quiz.service';
 
@@ -13,14 +13,43 @@ import { QuizService } from 'src/app/service/quiz.service';
 
 export class MainGameScreenComponent {
   private firestore: Firestore = inject(Firestore);
-  value: number = 0;
+  private TimeLimitSubscription!: Subscription;
+  remainingTime: number = 0;
+  starttimeLimit: number = this.quizService.startTimeLimit;
+  Hp: number = 0;
+  startHp: number = this.quizService.startHp;
 
   constructor(
-    private firestoreClient: FirestoreClientService
-  ){}
+    private firestoreClient: FirestoreClientService,
+    private quizService: QuizService,
+    private router: Router
+  ){
+    this.quizService.timeLimitCount();
+  }
+
+  ngOnInit(){
+    this.TimeLimitSubscription = this.quizService._timeSub$.subscribe(time =>{
+      this.remainingTime = time;
+      if(time == 0){
+        this.unsub();
+        this.TimeLimitSubscription.unsubscribe();
+        setTimeout(() => {
+          this.quizService.result = '負け';
+          this.router.navigateByUrl('/result');
+        }, 1000);
+      }
+    });
+  }
+
   //DBを監視して更新があれば反映させる
   private unsub = onSnapshot(doc(this.firestore, "rooms", this.firestoreClient.roomKey), (doc) => {
-    this.value = doc.get('enemyHp');
-    console.log("Current data: ", doc.get('enemyHp'));
-  })
+    this.Hp = doc.get('enemyHp');
+    this.quizService.enemyHp = this.Hp;
+    if(this.Hp <= 0) {
+      this.TimeLimitSubscription.unsubscribe();
+      this.unsub();
+      this.quizService.result = '勝ち';
+      this.router.navigateByUrl('/result');
+    }
+  });
 }

--- a/angular-app/src/app/pages/result/result.component.html
+++ b/angular-app/src/app/pages/result/result.component.html
@@ -3,5 +3,5 @@
 </div>
 
 <div class="win-or-loss-text">
-  勝ち
+  {{ result }}
 </div>

--- a/angular-app/src/app/pages/result/result.component.html
+++ b/angular-app/src/app/pages/result/result.component.html
@@ -1,5 +1,7 @@
 <div class="top-item-container">
-  <button mat-stroked-button class="back-button">戻る</button>
+  <button mat-stroked-button class="back-button" (click)="backLobby()">
+    戻る
+  </button>
 </div>
 
 <div class="win-or-loss-text">

--- a/angular-app/src/app/pages/result/result.component.ts
+++ b/angular-app/src/app/pages/result/result.component.ts
@@ -1,5 +1,7 @@
 import { Component } from '@angular/core';
+import { Router } from '@angular/router';
 import { FirestoreClientService } from 'src/app/service/firestore-client.service';
+import { QuizService } from 'src/app/service/quiz.service';
 
 @Component({
   selector: 'app-result',
@@ -11,6 +13,8 @@ export class ResultComponent {
   result: string = ''
   constructor(
     private firestoreClient: FirestoreClientService,
+    private router: Router,
+    private quizService: QuizService
   ){}
   ngOnInit(){
     this.roomKey = this.firestoreClient.roomKey;
@@ -21,6 +25,9 @@ export class ResultComponent {
         this.result = '負け';
       }
     })
-
+  }
+  backLobby(){
+    this.quizService.initQuiz();
+    this.router.navigateByUrl('/lobby');
   }
 }

--- a/angular-app/src/app/pages/result/result.component.ts
+++ b/angular-app/src/app/pages/result/result.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { FirestoreClientService } from 'src/app/service/firestore-client.service';
 
 @Component({
   selector: 'app-result',
@@ -6,5 +7,20 @@ import { Component } from '@angular/core';
   styleUrls: ['./result.component.scss']
 })
 export class ResultComponent {
+  roomKey: string = '';
+  result: string = ''
+  constructor(
+    private firestoreClient: FirestoreClientService,
+  ){}
+  ngOnInit(){
+    this.roomKey = this.firestoreClient.roomKey;
+    let room = this.firestoreClient.getRoom(this.roomKey).then(val =>{
+      if(val.enemyHp == 0) {
+        this.result = '勝ち';
+      }else{
+        this.result = '負け';
+      }
+    })
 
+  }
 }

--- a/angular-app/src/app/pages/signin/signin.component.html
+++ b/angular-app/src/app/pages/signin/signin.component.html
@@ -5,20 +5,37 @@
 
   <mat-card-content *ngIf="isVerified">
     <mat-form-field class="comment-input">
-      <input [(ngModel)]="email" matInput placeholder="Email" value="fukukou1256@gmail.com">
+      <input
+        [(ngModel)]="email"
+        matInput
+        placeholder="Email"
+        value="fukukou1256@gmail.com"
+        (keydown.enter)="login()"
+      />
     </mat-form-field>
     <mat-form-field class="comment-input">
-      <input [(ngModel)]="password" matInput type="password" placeholder="パスワード" value="piyo1234">
+      <input
+        [(ngModel)]="password"
+        matInput
+        type="password"
+        placeholder="パスワード"
+        value="piyo1234"
+        (keydown.enter)="login()"
+      />
     </mat-form-field>
     <mat-card-actions>
-      <button (click)="login()" mat-raised-button color="primary">ログイン</button>
+      <button (click)="login()" mat-raised-button color="primary">
+        ログイン
+      </button>
     </mat-card-actions>
   </mat-card-content>
 
   <mat-card-content *ngIf="!isVerified">
     <mat-card-title><h2>本人確認</h2></mat-card-title>
     送信されたメールから本人確認を行なってください。
-    <button (click)="reload()" mat-raised-button color="primary">ログイン画面へ</button>
+    <button (click)="reload()" mat-raised-button color="primary">
+      ログイン画面へ
+    </button>
   </mat-card-content>
   <mat-card-footer>
     <a routerLink="/signup">アカウント登録</a>

--- a/angular-app/src/app/pages/signin/signin.component.ts
+++ b/angular-app/src/app/pages/signin/signin.component.ts
@@ -2,7 +2,8 @@ import { Component, inject } from '@angular/core';
 
 import { Auth, onAuthStateChanged, signInWithEmailAndPassword } from '@angular/fire/auth';
 import { Router } from '@angular/router';
-import { Observable } from 'rxjs';
+import { ToastrService } from 'ngx-toastr';
+
 
 @Component({
   selector: 'app-signin',
@@ -18,6 +19,7 @@ export class SigninComponent {
   constructor(
     private auth: Auth = inject(Auth),
     private router: Router,
+    private toastr: ToastrService
   ){}
   ngOnInit() {
     if(this.auth.currentUser){//アカウント登録直後のログイン
@@ -26,6 +28,10 @@ export class SigninComponent {
   }
 
   login() {
+    if(!this.email || !this.password) {
+      console.log('a');
+      return;
+    }
     signInWithEmailAndPassword(this.auth, this.email, this.password).then(res => {
 
       if(!res.user.emailVerified){//本人確認されていない
@@ -33,7 +39,7 @@ export class SigninComponent {
       }else if(res.user.displayName == null){//ユーザ名登録が済んでいない(初回ログイン)
         this.router.navigateByUrl('/uup');
       }else{//全てOK、TOP画面へ
-        alert('ログイン成功しました。');
+        this.toastr.success('ログインしました。');
         this.router.navigateByUrl('/top');
       }
     }).catch(res => {
@@ -42,7 +48,6 @@ export class SigninComponent {
 
     });
   }
-
   reload(){
     this.ngOnInit();
   }

--- a/angular-app/src/app/question.ts
+++ b/angular-app/src/app/question.ts
@@ -14,10 +14,7 @@ export interface newQuestion {
   statement:string;
   answer:string;
 }
-export interface hp {
-  enemyHp: number
-}
-export interface rooms {
+export interface room {
   enemyHp: number;
   hostUser: string;
   startTime: Date;

--- a/angular-app/src/app/service/firestore-client.service.ts
+++ b/angular-app/src/app/service/firestore-client.service.ts
@@ -1,9 +1,8 @@
-import { Injectable, inject, resolveForwardRef } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Auth } from '@angular/fire/auth';
 import {  DocumentReference, Firestore, addDoc, collection, doc, getDoc, setDoc, updateDoc } from '@angular/fire/firestore';
 import { room, user } from '../question';
 import { Router } from '@angular/router';
-import { QuizService } from './quiz.service';
 
 @Injectable({
   providedIn: 'root'
@@ -93,7 +92,7 @@ export class FirestoreClientService {
       this._enemyHp = hp;
       updateDoc(doc(this.firestore, 'rooms', this._roomKey), {
         'enemyHp': hp
-      })
+      });
     }
     //スタート時間の更新
     async updateTime(): Promise<Date>{

--- a/angular-app/src/app/service/firestore-client.service.ts
+++ b/angular-app/src/app/service/firestore-client.service.ts
@@ -1,21 +1,29 @@
-import { Injectable, inject } from '@angular/core';
+import { Injectable, inject, resolveForwardRef } from '@angular/core';
 import { Auth } from '@angular/fire/auth';
 import {  DocumentReference, Firestore, addDoc, collection, doc, getDoc, setDoc, updateDoc } from '@angular/fire/firestore';
-import { hp, rooms, user } from '../question';
+import { room, user } from '../question';
 import { Router } from '@angular/router';
-import { update } from '@angular/fire/database';
+import { QuizService } from './quiz.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class FirestoreClientService {
-  private _user: user = {
+  private _userInfo: user = {
     name: '',
     isHost: false
   };
+  private _roomInfo: room = {
+    enemyHp: 0,
+    hostUser: '',
+    startTime: new Date()
+  }
+  private _enemyHp: number = 0;
   private _roomKey: string = '';
   private _uuid: string;
+  // = this.auth.currentUser? this.auth.currentUser.uid: '';
   private _userName: string | null;
+  // = this.auth.currentUser? this.auth.currentUser.displayName: '';
   private _isHost: boolean = false;
 
   constructor(
@@ -29,8 +37,8 @@ export class FirestoreClientService {
 
     //ルームドキュメント作成・初期値挿入(ルーム作成時のみ実行)
     async insertRoom(){
-      addDoc(collection(this.firestore, 'rooms'),<rooms>{
-        enemyHp: 100,
+      addDoc(collection(this.firestore, 'rooms'),<room>{
+        enemyHp: this._enemyHp,
         hostUser: this._uuid,
         startTime: new Date()
       }).then((documentReference: DocumentReference)=>{
@@ -57,20 +65,44 @@ export class FirestoreClientService {
       //doc('firebaseインスタンス', 'コレクションID', 'ルームキー', 'サブコレクションID', 'ユーザID')
       const userDoc = doc(this.firestore, 'rooms', this._roomKey, 'users', this._uuid);
       getDoc(userDoc).then(async value =>{
-        this._user = {
+        this._userInfo = {
           name: await value.get('name'),
           isHost: await value.get('isHost')
         };
-        console.log(this._user);
-        return this._user;
+        console.log(this._userInfo);
+        return this._userInfo;
       })
+    }
+
+    //ルームドキュメント取得
+    async getRoom(key: string): Promise<room>{
+      this._roomKey = key;
+      //doc('firebaseインスタンス', 'コレクションID', 'ルームキー')
+      const roomDoc = doc(this.firestore, 'rooms', this._roomKey);
+      const docVal = await getDoc(roomDoc);
+      this._roomInfo = {
+        enemyHp: docVal.get('enemyHp'),
+        hostUser: docVal.get('hostUser'),
+        startTime: docVal.get('startTime').toDate()
+      };
+      return  this._roomInfo;
     }
 
     //敵のHPを更新
     updateHp(hp: number){
+      this._enemyHp = hp;
       updateDoc(doc(this.firestore, 'rooms', this._roomKey), {
         'enemyHp': hp
       })
+    }
+    //スタート時間の更新
+    async updateTime(): Promise<Date>{
+      let time = new Date();
+      let startTime = new Date(time.setSeconds(time.getSeconds() + 5));
+      const docVal = updateDoc(doc(this.firestore, 'rooms', this._roomKey), {
+        'startTime': startTime
+      });
+      return startTime;
     }
 
     get roomKey(): string{

--- a/angular-app/src/app/service/quiz.service.ts
+++ b/angular-app/src/app/service/quiz.service.ts
@@ -1,24 +1,46 @@
 import { Injectable, inject } from '@angular/core';
-import { hp, questionTypes } from '../question';
+import { questionTypes } from '../question';
 import { QUESTIONS } from '../questions';
 import { FirestoreClientService } from './firestore-client.service';
+import { Observable, Subject, Subscription, interval } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class QuizService {
-  private _enemyHp: number = 100;
-  private _currentQuizCount = 0;
+  private _enemyHp: number = 0;
+  private _result: string = '';
+  private _damage: number = 10;
+  //敵HP・制限時間初期値
+  private _startHp: number = 300;
+  private _startTimeLimit: number = 180;
+  //問題文のプロパティ
+  private _currentQuizCount: number = 0;
   private _currentQuizStatement: string = '';
   private _currentQuizAnswer: string = '';
+  //ゲーム開始までのカウントダウン用プロパティ
+  private _timeCount: string = '';
+  private _countSub = new Subject<string>();
+  public _countSub$ = this._countSub.asObservable();
+  //制限時間カウントダウン用プロパティ
+  private _remainingTime: number = 0;
+  private _timeSub = new Subject<number>();
+  public _timeSub$ = this._timeSub.asObservable();
 
   constructor(
-    private firestoreCliant: FirestoreClientService
+    private firestoreCliant: FirestoreClientService,
   ) {
     this.createQuestion();
+    this.initQuiz();
+  }
+
+  //初期化
+  initQuiz(){
+    this._enemyHp = this._startHp;
+    this.firestoreCliant.updateHp(this._startHp);
   }
   //問題文の作成
-  createQuestion(){
+  private createQuestion(){
     const questions = QUESTIONS;
     let questionParameterX: string;
     let targetQuestion = questions[Math.floor(Math.random() * questions.length)];
@@ -44,11 +66,10 @@ export class QuizService {
     }
   }
   //answerGameComponentで回答ボタンが押された時に呼び出す
-  //入力が空の場合は数値型の−１を引数として受け取る
+  //入力が空の場合は数値型の−１を引数として受け取り不正解となる
   checkAnswer(answer: number): boolean{
-    const damage = 10;
     if(answer.toString() == this._currentQuizAnswer){
-      this._enemyHp -= damage;
+      this._enemyHp -= this._damage;
       this.firestoreCliant.updateHp(this._enemyHp);
       this.createQuestion();
       return true;
@@ -57,6 +78,38 @@ export class QuizService {
       return false;
     }
   }
+  //ゲーム開始までのカウントダウン
+  startTimer(startTime: Date){
+    const start: number = startTime.getTime();
+    const timer = interval(1).subscribe(() => {
+      const now: number = new Date().getTime();
+      const remainTime: number = start - now;
+      if(remainTime <= 1000) {
+        timer.unsubscribe();
+        this._timeCount = 'スタート';
+        this._countSub.next(this._timeCount);
+        return;
+      }
+      const difSec  = Math.floor(remainTime / 1000);
+      this._timeCount = difSec.toString();
+      this._countSub.next(this._timeCount);
+    });
+  }
+  //ゲーム終了までのカウントダウン
+  timeLimitCount(){
+    let timeLimit: number = this._startTimeLimit;
+    const timer = interval(1000).subscribe(() => {
+      this._remainingTime = timeLimit;
+      if(this._remainingTime == 0 || this._enemyHp == 0) {
+        this._remainingTime = timeLimit;
+        this._timeSub.next(this._remainingTime);
+        timer.unsubscribe();
+        return;
+      }
+      this._timeSub.next(this._remainingTime);
+      timeLimit-=1;
+    });
+  }
 
   get currentQuizCount(): number{
     return this._currentQuizCount;
@@ -64,5 +117,20 @@ export class QuizService {
   get currentQuizStatement(): string{
     return this._currentQuizStatement;
   }
+  get startTimeLimit(): number{
+    return this._startTimeLimit;
+  }
+  get result(): string{
+    return this._result;
+  }
+  get startHp(): number {
+    return this._startHp;
+  }
 
+  set result(result: string){
+    this._result = result;
+  }
+  set enemyHp(enemyHp: number) {
+    this._enemyHp = enemyHp;
+  }
 }

--- a/angular-app/src/app/service/quiz.service.ts
+++ b/angular-app/src/app/service/quiz.service.ts
@@ -1,8 +1,8 @@
-import { Injectable, inject } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { questionTypes } from '../question';
 import { QUESTIONS } from '../questions';
 import { FirestoreClientService } from './firestore-client.service';
-import { Observable, Subject, Subscription, interval } from 'rxjs';
+import {  Subject, interval } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
@@ -10,10 +10,10 @@ import { Observable, Subject, Subscription, interval } from 'rxjs';
 export class QuizService {
   private _enemyHp: number = 0;
   private _result: string = '';
-  private _damage: number = 10;
+  private _damage: number = 300;
   //敵HP・制限時間初期値
   private _startHp: number = 300;
-  private _startTimeLimit: number = 180;
+  private _startTimeLimit: number = 20;
   //問題文のプロパティ
   private _currentQuizCount: number = 0;
   private _currentQuizStatement: string = '';
@@ -97,19 +97,31 @@ export class QuizService {
   }
   //ゲーム終了までのカウントダウン
   timeLimitCount(){
-    let timeLimit: number = this._startTimeLimit;
+    this._remainingTime = this._startTimeLimit;
     const timer = interval(1000).subscribe(() => {
-      this._remainingTime = timeLimit;
       if(this._remainingTime == 0 || this._enemyHp == 0) {
-        this._remainingTime = timeLimit;
         this._timeSub.next(this._remainingTime);
         timer.unsubscribe();
         return;
       }
       this._timeSub.next(this._remainingTime);
-      timeLimit-=1;
+      this._remainingTime-=1;
     });
   }
+  // timeLimitCount(){
+  //   let timeLimit: number = this._startTimeLimit;
+  //   const timer = interval(1000).subscribe(() => {
+  //     this._remainingTime = timeLimit;
+  //     if(this._remainingTime == 0 || this._enemyHp == 0) {
+  //       this._remainingTime = timeLimit;
+  //       this._timeSub.next(this._remainingTime);
+  //       timer.unsubscribe();
+  //       return;
+  //     }
+  //     this._timeSub.next(this._remainingTime);
+  //     timeLimit-=1;
+  //   });
+  // }
 
   get currentQuizCount(): number{
     return this._currentQuizCount;

--- a/angular-app/src/styles.scss
+++ b/angular-app/src/styles.scss
@@ -4,6 +4,7 @@
 
 @include mat.core();
 
+@import 'ngx-toastr/toastr';
 
 // primary に先程作成した $custom-primary を指定
 $custom-primary: mat.define-palette(palette.$custom-primary);


### PR DESCRIPTION
・キーコピーボタンの実装 
・戻るボタン実装
## Checklist for Developer
- [x] 最新のdevelopブランチをPullした。Pulled the latest develop branch.
  - できない理由 Reason not to do: 
- [x] Pull RequestをIssueに紐付けた。Connected with the issue.
- [x] 自分をAssignした。Assigned yourself.
- [x] レビュワーを指定した。Assigned reviewer.

## 📝 そのほかの関連するIssue / Related issues other than connected one
<!-- ZenHubで紐付けられなかったIssueの番号を記載 -->
<!-- List down issue numbers which could not be connected with ZenHub -->
- #0
- #0
## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- ngx-toasterをインストール
- angular.jsonにtoaster.css追加
- ログイン成功時にトースターで通知する処理追加
- キーコピーボタン押下時にクリップボードにルームキーをコピーする処理追加
- キーコピー成功時にトースターで通知する処理追加
- ロビー画面の戻るボタン押下時にトップ画面に遷移する処理追加
- リザルト画面の戻るボタン押下時にロビー画面に遷移し、クイズサービスのメンバ変数のうち時間と敵のHPに関するものを初期化する処理追加

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->


## レビューするポイント (Points for review):
<!-- テストケースを箇条書きで。Issueに書いてあればコピーしてください。 -->
<!-- List down test cases for this PR. Or you can copy that from the issue. -->
 - 各フィールドでエンターを押した時サブミットできる
 - キーコピーボタン押下時に任意のルームIDをクリップボードにコピーできる
 - キーコピー成功時通知される
 - ロビー画面の戻るボタン押下でトップ画面に遷移する
 - リザルト画面の戻るボタン押下でロビー画面に遷移し、initQuiz()で制限時間と敵HPが初期化される。また、2回目以降のクイズで制限時間が一回目のクイズと同様にカウントされ、HPも一回目同様の挙動で減っていく。